### PR TITLE
Add new metric: file size of documents per vault / tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,7 +758,7 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "onepassword-exporter"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "onepassword-exporter"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ op_document_file_size_per_tag_bytes{tag="test"} 10494986
 op_document_file_size_per_vault_bytes{vault="36vhq4xz3r6hnemzadk33evi4a"} 10494986
 # HELP op_exporter_buildinfo Build information of this exporter.
 # TYPE op_exporter_buildinfo gauge
-op_exporter_buildinfo{version="0.2.0"} 1
+op_exporter_buildinfo{version="0.3.0"} 1
 # HELP op_group_count_total Total number of groups.
 # TYPE op_group_count_total gauge
 op_group_count_total 4

--- a/README.md
+++ b/README.md
@@ -81,13 +81,19 @@ Here is full example of available metrics, with all metrics enabled:
 op_account_current{created_at="2023-03-19T05:06:27Z",domain="my",id="??????????????????????????",name="**********",state="ACTIVE",type="FAMILY"} 1
 # HELP op_document_count_per_tag Number of documents per tag.
 # TYPE op_document_count_per_tag gauge
-op_document_count_per_tag{tag="test"} 1
+op_document_count_per_tag{tag="test"} 4
 # HELP op_document_count_per_vault Number of documents per vault.
 # TYPE op_document_count_per_vault gauge
-op_document_count_per_vault{vault="36vhq4xz3r6hnemzadk33evi4a"} 1
+op_document_count_per_vault{vault="36vhq4xz3r6hnemzadk33evi4a"} 4
 # HELP op_document_count_total Total number of documents.
 # TYPE op_document_count_total gauge
-op_document_count_total 1
+op_document_count_total 4
+# HELP op_document_file_size_per_tag_bytes Size of file in documents per tag, in bytes.
+# TYPE op_document_file_size_per_tag_bytes gauge
+op_document_file_size_per_tag_bytes{tag="test"} 10494986
+# HELP op_document_file_size_per_vault_bytes Size of file in documents per vault, in bytes.
+# TYPE op_document_file_size_per_vault_bytes gauge
+op_document_file_size_per_vault_bytes{vault="36vhq4xz3r6hnemzadk33evi4a"} 10494986
 # HELP op_exporter_buildinfo Build information of this exporter.
 # TYPE op_exporter_buildinfo gauge
 op_exporter_buildinfo{version="0.2.0"} 1

--- a/examples/grafana-dashboard/dashboard.json
+++ b/examples/grafana-dashboard/dashboard.json
@@ -1,4 +1,44 @@
 {
+  "__inputs": [],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "gauge",
+      "name": "Gauge",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.2.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -19,6 +59,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
+  "id": null,
   "links": [],
   "panels": [
     {
@@ -1793,7 +1834,7 @@
             "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "",
+            "axisLabel": "op_document_count_per_vault",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "barWidthFactor": 0.6,
@@ -1837,7 +1878,28 @@
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "op_document_file_size_per_vault_bytes"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "custom.axisLabel",
+                "value": "op_document_file_size_per_vault_bytes"
+              },
+              {
+                "id": "unit",
+                "value": "decbytes"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 10,
@@ -1874,6 +1936,23 @@
           "legendFormat": "{{vault}}",
           "range": true,
           "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "op_document_file_size_per_vault_bytes",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{vault}}",
+          "range": true,
+          "refId": "B",
           "useBackend": false
         }
       ],
@@ -2332,7 +2411,7 @@
             "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "",
+            "axisLabel": "op_document_count_per_tag",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "barWidthFactor": 0.6,
@@ -2376,7 +2455,28 @@
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "op_document_file_size_per_tag_bytes"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "custom.axisLabel",
+                "value": "op_document_file_size_per_tag_bytes"
+              },
+              {
+                "id": "unit",
+                "value": "decbytes"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 10,
@@ -2413,6 +2513,23 @@
           "legendFormat": "{{tag}}",
           "range": true,
           "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "op_document_file_size_per_tag_bytes",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{tag}}",
+          "range": true,
+          "refId": "B",
           "useBackend": false
         }
       ],

--- a/examples/grafana-dashboard/docker-compose.yaml
+++ b/examples/grafana-dashboard/docker-compose.yaml
@@ -27,6 +27,7 @@ services:
     ports:
       - ${GRAFANA_HOST:-127.0.0.1}:${GRAFANA_PORT:-3000}:3000
     volumes:
+      - grafana-data:/var/lib/grafana
       - ./dashboard.json:/var/lib/grafana/dashboards/dashboard.json
     configs:
       - source: datasource.yaml
@@ -87,4 +88,5 @@ configs:
           - onepassword-exporter:9999
 
 volumes:
+  grafana-data:
   prometheus-data:

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,6 +113,12 @@ op_document_count_per_vault{vault="36vhq4xz3r6hnemzadk33evi4a"} 4
 # HELP op_document_count_total Total number of documents.
 # TYPE op_document_count_total gauge
 op_document_count_total 4
+# HELP op_document_file_size_per_tag_bytes Size of file in documents per tag, in bytes.
+# TYPE op_document_file_size_per_tag_bytes gauge
+op_document_file_size_per_tag_bytes{tag="test"} 10494986
+# HELP op_document_file_size_per_vault_bytes Size of file in documents per vault, in bytes.
+# TYPE op_document_file_size_per_vault_bytes gauge
+op_document_file_size_per_vault_bytes{vault="36vhq4xz3r6hnemzadk33evi4a"} 10494986
 # HELP op_exporter_buildinfo Build information of this exporter.
 # TYPE op_exporter_buildinfo gauge
 op_exporter_buildinfo{version="0.2.0"} 1

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,7 +121,7 @@ op_document_file_size_per_tag_bytes{tag="test"} 10494986
 op_document_file_size_per_vault_bytes{vault="36vhq4xz3r6hnemzadk33evi4a"} 10494986
 # HELP op_exporter_buildinfo Build information of this exporter.
 # TYPE op_exporter_buildinfo gauge
-op_exporter_buildinfo{version="0.2.0"} 1
+op_exporter_buildinfo{version="0.3.0"} 1
 # HELP op_group_count_total Total number of groups.
 # TYPE op_group_count_total gauge
 op_group_count_total 4

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,13 +106,13 @@ mod tests {
 op_account_current{created_at="2023-03-19T05:06:27Z",domain="my",id="??????????????????????????",name="**********",state="ACTIVE",type="FAMILY"} 1
 # HELP op_document_count_per_tag Number of documents per tag.
 # TYPE op_document_count_per_tag gauge
-op_document_count_per_tag{tag="test"} 1
+op_document_count_per_tag{tag="test"} 4
 # HELP op_document_count_per_vault Number of documents per vault.
 # TYPE op_document_count_per_vault gauge
-op_document_count_per_vault{vault="36vhq4xz3r6hnemzadk33evi4a"} 1
+op_document_count_per_vault{vault="36vhq4xz3r6hnemzadk33evi4a"} 4
 # HELP op_document_count_total Total number of documents.
 # TYPE op_document_count_total gauge
-op_document_count_total 1
+op_document_count_total 4
 # HELP op_exporter_buildinfo Build information of this exporter.
 # TYPE op_exporter_buildinfo gauge
 op_exporter_buildinfo{version="0.2.0"} 1

--- a/src/metrics_collector/build_info.rs
+++ b/src/metrics_collector/build_info.rs
@@ -36,7 +36,7 @@ mod tests {
         // Assert
         assert_eq!(
             OP_EXPORTER_BUILDINFO
-                .get_metric_with_label_values(&["0.2.0"])?
+                .get_metric_with_label_values(&["0.3.0"])?
                 .get(),
             1
         );

--- a/src/metrics_collector/document.rs
+++ b/src/metrics_collector/document.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use lazy_static::lazy_static;
 #[cfg(test)]
 use mockall::predicate::*;
-use prometheus::{register_int_gauge_vec, IntGaugeVec};
+use prometheus::{register_int_gauge_vec, HistogramVec, IntGaugeVec};
 use serde::Deserialize;
 
 use super::OpMetricsCollector;
@@ -24,6 +24,18 @@ lazy_static! {
         &["tag"]
     )
     .unwrap();
+    static ref OP_DOCUMENT_FILE_SIZE_PER_VAULT: IntGaugeVec = register_int_gauge_vec!(
+        "op_document_file_size_per_vault_bytes",
+        "Size of file in documents per vault, in bytes.",
+        &["vault"],
+    )
+    .unwrap();
+    static ref OP_DOCUMENT_FILE_SIZE_PER_TAG: IntGaugeVec = register_int_gauge_vec!(
+        "op_document_file_size_per_tag_bytes",
+        "Size of file in documents per tag, in bytes.",
+        &["tag"],
+    )
+    .unwrap();
 }
 
 #[derive(Deserialize, Debug)]
@@ -36,6 +48,8 @@ struct Document {
     #[allow(dead_code)]
     pub(crate) version: i32,
     pub(crate) vault: DocumentVault,
+    #[serde(rename = "overview.ainfo")]
+    pub(crate) overview_ainfo: Option<String>,
     #[allow(dead_code)]
     pub(crate) last_edited_by: String,
     #[allow(dead_code)]
@@ -68,13 +82,26 @@ impl OpMetricsCollector {
         // Gather metrics
         let mut count_per_vault = HashMap::new();
         let mut count_per_tag = HashMap::new();
+        let mut file_size_per_vault = HashMap::new();
+        let mut file_size_per_tag = HashMap::new();
+
         for document in &documents {
             let vault_id = document.vault.id.clone();
-            *count_per_vault.entry(vault_id).or_insert(0) += 1;
-
+            let file_size = match &document.overview_ainfo {
+                Some(overview_ainfo) => match parse_file_size_bytes(overview_ainfo) {
+                    Some(file_size) => file_size,
+                    None => 0,
+                },
+                None => 0,
+            };
             let tags = document.tags.clone().unwrap_or_default();
+
+            *count_per_vault.entry(vault_id.clone()).or_insert(0) += 1;
+            *file_size_per_vault.entry(vault_id).or_insert(0) += file_size;
+
             for tag in tags {
-                *count_per_tag.entry(tag).or_insert(0) += 1;
+                *count_per_tag.entry(tag.clone()).or_insert(0) += 1;
+                *file_size_per_tag.entry(tag).or_insert(0) += file_size;
             }
         }
 
@@ -93,7 +120,53 @@ impl OpMetricsCollector {
                 .with_label_values(&[tag])
                 .set(*count);
         });
+        file_size_per_vault.iter().for_each(|(vault, size)| {
+            OP_DOCUMENT_FILE_SIZE_PER_VAULT
+                .with_label_values(&[vault])
+                .set(*size);
+        });
+        file_size_per_tag.iter().for_each(|(tag, size)| {
+            OP_DOCUMENT_FILE_SIZE_PER_TAG
+                .with_label_values(&[tag])
+                .set(*size);
+        });
     }
+}
+
+/// Parse file size (e.g. `"10 bytes"`, `"1 KB"`) to bytes.
+// * NOTE: Accurate file sizes not available in the output because 1Password truncate it when goes over KB.
+fn parse_file_size_bytes(s: &String) -> Option<i64> {
+    // Split size and unit
+    let (size, unit) = match s.split_once(' ') {
+        Some((size, unit)) => (size, unit),
+        None => {
+            log::error!("Invalid file size format: {}", s);
+            return None;
+        }
+    };
+
+    // Parse size
+    let size = match size.parse::<i64>() {
+        Ok(size) => size,
+        Err(e) => {
+            log::error!("Failed to parse file size: {}", e);
+            return None;
+        }
+    };
+
+    // Convert unit to multiplier
+    let multiplier = match unit {
+        "bytes" => 1,
+        "KB" => 1024,
+        "MB" => 1024 * 1024,
+        "GB" => 1024 * 1024 * 1024,
+        _ => {
+            log::error!("Unknown unit: {}", unit);
+            return None;
+        }
+    };
+
+    Some(size * multiplier)
 }
 
 #[cfg(test)]
@@ -127,6 +200,18 @@ mod tests {
                 .get_metric_with_label_values(&["test"])?
                 .get(),
             4
+        );
+        assert_eq!(
+            OP_DOCUMENT_FILE_SIZE_PER_VAULT
+                .get_metric_with_label_values(&["36vhq4xz3r6hnemzadk33evi4a"])?
+                .get(),
+            10494986
+        );
+        assert_eq!(
+            OP_DOCUMENT_FILE_SIZE_PER_TAG
+                .get_metric_with_label_values(&["test"])?
+                .get(),
+            10494986
         );
 
         Ok(())

--- a/src/metrics_collector/document.rs
+++ b/src/metrics_collector/document.rs
@@ -114,19 +114,19 @@ mod tests {
             OP_DOCUMENT_COUNT_TOTAL
                 .get_metric_with_label_values(&[])?
                 .get(),
-            1
+            4
         );
         assert_eq!(
             OP_DOCUMENT_COUNT_PER_VAULT
                 .get_metric_with_label_values(&["36vhq4xz3r6hnemzadk33evi4a"])?
                 .get(),
-            1
+            4
         );
         assert_eq!(
             OP_DOCUMENT_COUNT_PER_TAG
                 .get_metric_with_label_values(&["test"])?
                 .get(),
-            1
+            4
         );
 
         Ok(())

--- a/src/metrics_collector/document.rs
+++ b/src/metrics_collector/document.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use lazy_static::lazy_static;
 #[cfg(test)]
 use mockall::predicate::*;
-use prometheus::{register_int_gauge_vec, HistogramVec, IntGaugeVec};
+use prometheus::{register_int_gauge_vec, IntGaugeVec};
 use serde::Deserialize;
 
 use super::OpMetricsCollector;

--- a/tests/fixtures/document.json
+++ b/tests/fixtures/document.json
@@ -1,11 +1,58 @@
 [
   {
-    "id": "lg4ukcbfhd54tgb3ixzmv7lrcu",
+    "id": "vg5ia5rapo2rqixgg7tmmo47ri",
+    "title": "Tiny File",
+    "tags": [
+      "test"
+    ],
+    "version": 12,
+    "vault": {
+      "id": "36vhq4xz3r6hnemzadk33evi4a",
+      "name": ""
+    },
+    "overview.ainfo": "10 bytes",
+    "last_edited_by": "K3MAYGGYRZA2XN2AMQ5ADZJ6VI",
+    "created_at": "2024-09-23T11:17:12Z",
+    "updated_at": "2024-09-23T11:37:00Z"
+  },
+  {
+    "id": "ybo3wgmxgq26glyaapd6l432su",
     "title": "Empty Document",
     "tags": [
       "test"
     ],
-    "version": 3,
+    "version": 2,
+    "vault": {
+      "id": "36vhq4xz3r6hnemzadk33evi4a",
+      "name": ""
+    },
+    "last_edited_by": "K3MAYGGYRZA2XN2AMQ5ADZJ6VI",
+    "created_at": "2024-09-23T11:35:28Z",
+    "updated_at": "2024-09-23T11:37:00Z"
+  },
+  {
+    "id": "bgtzwwcy63c4dhjd2qdq4mytsm",
+    "title": "Moderate File",
+    "tags": [
+      "test"
+    ],
+    "version": 5,
+    "vault": {
+      "id": "36vhq4xz3r6hnemzadk33evi4a",
+      "name": ""
+    },
+    "overview.ainfo": "10 MB",
+    "last_edited_by": "K3MAYGGYRZA2XN2AMQ5ADZJ6VI",
+    "created_at": "2024-09-23T11:15:34Z",
+    "updated_at": "2024-09-23T11:37:00Z"
+  },
+  {
+    "id": "lg4ukcbfhd54tgb3ixzmv7lrcu",
+    "title": "Regular File",
+    "tags": [
+      "test"
+    ],
+    "version": 5,
     "vault": {
       "id": "36vhq4xz3r6hnemzadk33evi4a",
       "name": ""
@@ -13,6 +60,6 @@
     "overview.ainfo": "9 KB",
     "last_edited_by": "K3MAYGGYRZA2XN2AMQ5ADZJ6VI",
     "created_at": "2024-08-04T04:06:31Z",
-    "updated_at": "2024-09-03T12:57:17Z"
+    "updated_at": "2024-09-23T11:37:00Z"
   }
 ]


### PR DESCRIPTION
Add new metrics:

- `op_document_file_size_per_vault_bytes`
- `op_document_file_size_per_tag_bytes`

Each represents the sum of documents' **approximate** file size per vault or tag. Please note that due to limitations of the 1Password CLI itself (which cuts file sizes in KB/MB), actual file sizes may differ.

Resolves #10.